### PR TITLE
Look for NSArray rather than NSMutableArray in ichat data

### DIFF
--- a/ichat2json/main.m
+++ b/ichat2json/main.m
@@ -33,7 +33,7 @@ int main(int argc, const char * argv[]) {
         NSMutableArray *ims = [NSMutableArray array];
         NSMutableSet *people = [NSMutableSet set];
         for (id object in root) {
-            if ([object isKindOfClass:[NSMutableArray class]]) {
+            if ([object isKindOfClass:[NSArray class]]) {
                 for (id sub in object) {
                     if ([sub isKindOfClass:[InstantMessage class]]) {
                         InstantMessage *im = (InstantMessage *) sub;


### PR DESCRIPTION
ichat2json didn't work at all for me (and, therefore, matrix-puppet-imessage didn't work either). It would return 0 and not throw any errors, but give no output.

Inspecting the `root` object shows that it contains an `NSArray`, not an `NSMutableArray`. I'm guessing this changed at some point since it obviously must have worked before, but since `NSMutableArray` is a subclass of `NSArray` I believe this should work no matter which one comes back from `NSKeyedUnarchiver`.

<img width="281" alt="screen shot 2018-09-20 at 3 35 57 pm" src="https://user-images.githubusercontent.com/522101/45850704-f0e9f100-bceb-11e8-8503-77d62a080de1.png">
